### PR TITLE
Use vim.keymap instead of my logic here

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,37 @@ A port for Neovim to implement [dwm.vim][]'s features and more.
       master_pane_count = 1,
       master_pane_width = '60%',
     }
-    dwm.map('<C-j>', '<C-w>w')
-    dwm.map('<C-k>', '<C-w>W')
-    dwm.map('<A-CR>', dwm.focus)
-    dwm.map('<C-@>', dwm.focus)
-    dwm.map('<C-Space>', dwm.focus)
-    dwm.map('<C-l>', dwm.grow)
-    dwm.map('<C-h>', dwm.shrink)
-    dwm.map('<C-n>', dwm.new)
-    dwm.map('<C-q>', dwm.rotateLeft)
-    dwm.map('<C-s>', dwm.rotate)
-    dwm.map('<C-c>', function()
-      -- You can use any Lua function to map.
-      vim.api.nvim_echo({{'closing!', 'WarningMsg'}}, false, {})
+    vim.keymap.set('n', '<C-j>', '<C-w>w')
+    vim.keymap.set('n', '<C-k>', '<C-w>W')
+    vim.keymap.set('n', '<A-CR>', dwm.focus)
+    vim.keymap.set('n', '<C-@>', dwm.focus)
+    vim.keymap.set('n', '<C-Space>', dwm.focus)
+    vim.keymap.set('n', '<C-l>', dwm.grow)
+    vim.keymap.set('n', '<C-h>', dwm.shrink)
+    vim.keymap.set('n', '<C-n>', dwm.new)
+    vim.keymap.set('n', '<C-q>', dwm.rotateLeft)
+    vim.keymap.set('n', '<C-s>', dwm.rotate)
+    vim.keymap.set('n', '<C-c>', function()
+      vim.notify('closing!', vim.log.levels.INFO)
       dwm.close()
     end)
+
+    -- For users that do not have vim.keymap
+    -- dwm.map('<C-j>', '<C-w>w')
+    -- dwm.map('<C-k>', '<C-w>W')
+    -- dwm.map('<A-CR>', dwm.focus)
+    -- dwm.map('<C-@>', dwm.focus)
+    -- dwm.map('<C-Space>', dwm.focus)
+    -- dwm.map('<C-l>', dwm.grow)
+    -- dwm.map('<C-h>', dwm.shrink)
+    -- dwm.map('<C-n>', dwm.new)
+    -- dwm.map('<C-q>', dwm.rotateLeft)
+    -- dwm.map('<C-s>', dwm.rotate)
+    -- dwm.map('<C-c>', function()
+    --   -- You can use any Lua function to map.
+    --   vim.notify('closing!', vim.log.levels.INFO)
+    --   dwm.close()
+    -- end)
 
     -- When b:dwm_disabled is set, all features are disabled.
     vim.cmd[[au BufRead * if &previewwindow | let b:dwm_disabled = 1 | endif]]

--- a/lua/dwm/dwm.lua
+++ b/lua/dwm/dwm.lua
@@ -193,6 +193,10 @@ function M:wincmd(cmd)
 end -- luacheck: ignore 212
 
 function M:map(lhs, f)
+  if vim.keymap then
+    vim.keymap.set("n", lhs, f, { silent = true })
+    return
+  end
   local rhs
   if type(f) == "function" then
     if not _G[self.func_var_name] then


### PR DESCRIPTION
Now Neovim HEAD have `vim.keymap` and we can map any Lua function
directly. With this patch, `dwm:map()` uses `vim.keymap` when available.